### PR TITLE
Fixes broken link in footer.yml

### DIFF
--- a/_data/footer.yml
+++ b/_data/footer.yml
@@ -7,7 +7,7 @@
   url: /research/
 
 - title: News
-  url: /news/
+  url: /articles/
 
 - title: About
   url: /about/


### PR DESCRIPTION
`news` was renamed to `articles` but it looks like you missed this one :smiley: 